### PR TITLE
impl http event in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,18 @@ They'll be accessible through
 local banking = require('extensions.banking')
 ```
 
+### How to export my functions?
+
 Also `extensions/config.yml` describes how to export those modules in
-serverless style. For now we'll support the only event `binary`:
+serverless style.
+
+For now we'll support two types of events:
+- `binary`
+- `http`
+
+HTTP event supports any kind of HTTP's methods: GET, POST, PUT and etc.
+
+Here is a little example:
 
 ```yml
 functions:
@@ -21,4 +31,14 @@ functions:
     - binary:
       # It'll assign _G.__transfer_money = banking.transfer_money
         path: __transfer_money
+
+  get_balance:
+    module: banking
+    handler: http_get_balance
+    events:
+    - http:
+      # It'll create the new HTTP endpoint by the next path:
+      # http://<your_domain>:<http_port>/get_balance
+        path: "/get_balance"
+        method: GET
 ```

--- a/test/banking_config/extensions/banking.lua
+++ b/test/banking_config/extensions/banking.lua
@@ -1,4 +1,5 @@
 local checks = require('checks')
+local json = require('json')
 -- local extensions = require('cartridge').service_get('extensions')
 
 local function customer_add(customer_id, fullname)
@@ -8,23 +9,49 @@ local function customer_add(customer_id, fullname)
     )
 end
 
+local function http_customer_add(request)
+    checks('table')
+    local data = request:json()
+
+    local ok, err = box.space.customer:insert(
+        {tonumber(data.customer_id), data.fullname}
+    )
+
+    return { body = json.encode({ status = not err and "Success" or "Fail", result = ok}),
+             status = not err and 200 or 500 }
+end
+
 local function account_add(customer_id, account_id, name)
     checks('number', 'number', 'string')
     return box.space.account:insert(
-        {customer_id, account_id, name, 0}
+        {tonumber(customer_id), account_id, name, 0}
     )
+end
+
+local function http_account_add(request)
+    checks('table')
+    local data = request:json()
+
+    local ok, err = box.space.account:insert(
+        {tonumber(data.customer_id), tonumber(data.account_id), data.name, 0}
+    )
+
+    return { body = json.encode({ status = not err and "Success" or "Fail", result = ok}),
+             status = not err and 200 or 500 }
 end
 
 local function transfer_money(account_from, account_to, amount)
     box.begin()
-    box.space.account:update({account_to}, {{'+', 'balance', amount}})
-    box.space.account:update({account_from}, {{'-', 'balance', amount}})
+    box.space.account:update({account_to}, {{'+', 4, amount}})
+    box.space.account:update({account_from}, {{'-', 4, amount}})
     box.commit()
     return true
 end
 
 return {
     customer_add = customer_add,
+    http_customer_add = http_customer_add,
     account_add = account_add,
+    http_account_add = http_account_add,
     transfer_money = transfer_money,
 }

--- a/test/banking_config/extensions/config.yml
+++ b/test/banking_config/extensions/config.yml
@@ -7,11 +7,23 @@ functions:
     events:
     - binary: {path: customer_add}
 
+  http_customer_add:
+    module: extensions.banking
+    handler: http_customer_add
+    events:
+    - http: {path: /customer_add, method: POST}
+
   account_add:
     module: extensions.banking
     handler: account_add
     events:
     - binary: {path: account_add}
+
+  http_account_add:
+    module: extensions.banking
+    handler: http_account_add
+    events:
+    - http: {path: /account_add, method: POST}
 
   transfer_money:
     module: extensions.banking

--- a/test/common_test.lua
+++ b/test/common_test.lua
@@ -214,6 +214,7 @@ function g.test_functions_errors()
             }),
         }}
     )
+
 end
 
 function g.test_export_errors()

--- a/test/http_event_test.lua
+++ b/test/http_event_test.lua
@@ -1,0 +1,119 @@
+local fio = require('fio')
+local yaml = require('yaml')
+local t = require('luatest')
+local g = t.group()
+
+local test_helper = require('test.helper')
+local helpers = require('cartridge.test-helpers')
+
+local http = require('http.client')
+
+g.before_all = function()
+    g.cluster = helpers.Cluster:new({
+        datadir = fio.tempdir(),
+        use_vshard = false,
+        server_command = test_helper.server_command,
+        replicasets = {{
+            alias = 'loner',
+            uuid = helpers.uuid('a'),
+            roles = {'extensions'},
+            servers = {{
+                instance_uuid = helpers.uuid('a', 'a', 1)
+            }},
+        }}
+    })
+
+    g.cluster:start()
+end
+
+g.after_all = function()
+    g.cluster:stop()
+    fio.rmtree(g.cluster.datadir)
+end
+
+local function set_sections(sections)
+    return g.cluster.main_server:graphql({
+        query = [[
+            mutation($sections: [ConfigSectionInput!]) {
+                cluster {
+                    config(sections: $sections) {}
+                }
+            }
+        ]],
+        variables = {sections = sections},
+    })
+end
+
+local function make_self_http_request(method, path, opts)
+    local options = opts or {}
+    local server_uri = ("localhost:%s"):format(g.cluster.main_server.http_port)
+
+    return http.request(method, server_uri .. path, nil, options)
+end
+
+function g.test_http_disabled()
+    os.setenv('TARANTOOL_HTTP_ENABLED', 'FALSE')
+    g.cluster.main_server:stop()
+    g.cluster.main_server:start()
+
+    g.cluster.main_server.net_box:eval([[
+        local cartridge = require('cartridge')
+
+        local conf = {}
+        conf['extensions/config.yml'] = require('yaml').encode({
+            functions = {x = {
+                module = 'extensions.box',
+                handler = 'cat',
+                events = {{
+                    http = { path = '/cat', method = 'GET' }
+                }}
+            }}
+        })
+        conf['extensions/box.lua'] = "return { cat = function() end }"
+
+        return cartridge.config_patch_clusterwide(conf)
+    ]])
+
+    local res = make_self_http_request('GET', '/cat', {timeout = 2})
+    t.assert_items_equals(res, {reason = "Couldn't connect to server", status = 595})
+end
+
+function g.test_http_event_removing()
+    os.setenv('TARANTOOL_HTTP_ENABLED', 'TRUE')
+    g.cluster.main_server:stop()
+    g.cluster.main_server:start()
+
+    local config = {{
+        filename = 'extensions/config.yml',
+        content = yaml.encode({
+            functions = {x = {
+                module = 'extensions.box',
+                handler = 'cat',
+                events = {{
+                    http = { path = '/cat', method = 'GET' }
+                }}
+            }}
+        })
+    }, {
+        filename = 'extensions/box.lua',
+        content = 'return { cat = function() return { status = 200, body = \"Meow\" } end}'
+    }}
+
+    set_sections(config)
+    local res = make_self_http_request('GET', '/cat')
+    t.assert_items_equals(
+        { status = res.status, body = res.body},
+        { status = 200, body = "Meow"}
+    )
+
+    set_sections({{
+        filename = 'extensions/config.yml',
+        content = yaml.encode({
+            functions = {}
+        })
+    }})
+    t.assert_is(
+        make_self_http_request('GET', '/cat').status,
+        404
+    )
+end


### PR DESCRIPTION
## Motivation

During of development the "Try Tarantool" service we need to give an opportunity for a user to export his first functions via HTTP and get the first result without installing `tarantool` and `tarantoolctl`.   

This PR extends the current mechanism and adds a new type of event called `http`. 

## TODO

- [x] Remove HTTP handler if the new config doesn't exist any bindings with that endpoint

Also closes #4 