### PR TITLE
Reorganize tests

### DIFF
--- a/test/binary_test.lua
+++ b/test/binary_test.lua
@@ -1,0 +1,99 @@
+local fio = require('fio')
+local yaml = require('yaml')
+local t = require('luatest')
+local h = require('test.helper')
+local g = t.group()
+
+g.before_all(function()
+    g.cluster = h.Cluster:new({
+        datadir = fio.tempdir(),
+        use_vshard = false,
+        server_command = h.server_command,
+        replicasets = {{
+            alias = 'loner',
+            roles = {'extensions'},
+            servers = 1,
+        }},
+    })
+
+    g.cluster:start()
+    g.srv = g.cluster.main_server
+end)
+
+g.after_all(function()
+    g.cluster:stop()
+    fio.rmtree(g.cluster.datadir)
+end)
+
+
+function g.test_runtime()
+    local extensions_cfg = yaml.encode({
+        functions = {
+            operate = {
+                module = 'extensions.main',
+                handler = 'operate',
+                events = {{
+                    binary = {path = 'operate'}
+                }}
+            },
+            math_abs = {
+                module = 'math',
+                handler = 'abs',
+                events = {{
+                    binary = {path = 'math_abs'}
+                }}
+            }
+        }
+    })
+
+    h.set_sections(g.srv, {{
+        filename = 'extensions/config.yml',
+        content = extensions_cfg,
+    }, {
+        filename = 'extensions/main.lua',
+        content = [[
+            local function M()
+                return require('extensions.main')
+            end
+
+            local function operate()
+                return 1
+            end
+
+            return {
+                M = M,
+                require = require,
+                operate = operate,
+            }
+        ]],
+    }})
+
+    t.assert_equals(g.srv.net_box:call('math_abs', {-3}), 3)
+    t.assert_equals(g.srv.net_box:call('operate'), 1)
+    g.srv.net_box:eval([[
+        assert(package.loaded['extensions.main'], 'Extension not loaded')
+        local M = require('extensions.main')
+        assert(M == M.M(), 'Extension was reloaded twice')
+        assert(require ~= M.require, 'Upvalue "require" is broken')
+    ]])
+
+    h.set_sections(g.srv, {{
+        filename = 'extensions/config.yml',
+        content = extensions_cfg,
+    }, {
+        filename = 'extensions/main.lua',
+        content = [[
+            local function operate()
+                return 2
+            end
+
+            return {
+                operate = operate,
+            }
+        ]],
+    }})
+
+    t.assert_equals(g.srv.net_box:call('operate'), 2)
+
+    t.assert_equals(h.get_state(g.srv), 'RolesConfigured')
+end

--- a/test/common_test.lua
+++ b/test/common_test.lua
@@ -1,59 +1,37 @@
 local fio = require('fio')
 local yaml = require('yaml')
 local t = require('luatest')
+local h = require('test.helper')
 local g = t.group()
 
-local test_helper = require('test.helper')
-local helpers = require('cartridge.test-helpers')
+local error_prefix = "Invalid extensions config: "
 
-g.before_all = function()
-    g.cluster = helpers.Cluster:new({
+g.before_all(function()
+    g.cluster = h.Cluster:new({
         datadir = fio.tempdir(),
         use_vshard = false,
-        server_command = test_helper.server_command,
+        server_command = h.server_command,
         replicasets = {{
             alias = 'loner',
-            uuid = helpers.uuid('a'),
             roles = {'extensions'},
-            servers = {{
-                instance_uuid = helpers.uuid('a', 'a', 1)
-            }},
+            servers = 1,
         }},
     })
 
     g.cluster:start()
-end
+    g.srv = g.cluster.main_server
+end)
 
-g.after_all = function()
+g.after_all(function()
     g.cluster:stop()
     fio.rmtree(g.cluster.datadir)
-end
-
-local function get_state()
-    return g.cluster.main_server.net_box:eval([[
-        return require('cartridge.confapplier').get_state()
-    ]])
-end
-
-local error_prefix = "Invalid extensions config: "
-local function set_sections(sections)
-    return g.cluster.main_server:graphql({
-        query = [[
-            mutation($sections: [ConfigSectionInput!]) {
-                cluster {
-                    config(sections: $sections) {}
-                }
-            }
-        ]],
-        variables = {sections = sections},
-    })
-end
+end)
 
 function g.test_require_errors()
     t.assert_error_msg_equals(
         "extensions/main.lua:1: bad argument #1 to 'require'" ..
         " (string expected, got cdata)",
-        set_sections, {{
+        h.set_sections, g.srv, {{
             filename = 'extensions/main.lua',
             content = 'require(box.NULL)',
         }}
@@ -62,7 +40,7 @@ function g.test_require_errors()
     t.assert_error_msg_equals(
         "extensions/main.lua:1: loop or previous error loading" ..
         " module 'extensions.main'",
-        set_sections, {{
+        h.set_sections, g.srv, {{
             filename = 'extensions/main.lua',
             content = 'require("extensions.main")',
         }}
@@ -70,7 +48,7 @@ function g.test_require_errors()
 
     t.assert_error_msg_equals(
         "extensions/main.lua:1: unexpected symbol near '!'",
-        set_sections, {{
+        h.set_sections, g.srv, {{
             filename = 'extensions/main.lua',
             content = '! Syntax error',
         }}
@@ -78,7 +56,7 @@ function g.test_require_errors()
 
     t.assert_error_msg_equals(
         "extensions/main.lua:1: ###",
-        set_sections, {{
+        h.set_sections, g.srv, {{
             filename = 'extensions/main.lua',
             content = 'error("###")',
         }}
@@ -87,7 +65,7 @@ function g.test_require_errors()
     t.assert_error_msg_equals(
         "module 'extensions.main' not found:\n" ..
         "\tno section 'extensions/main.lua' in config",
-        set_sections, {{
+        h.set_sections, g.srv, {{
             filename = 'extensions/main.lua.yml',
             content = '{"This is not a script"}',
         }}
@@ -96,7 +74,7 @@ function g.test_require_errors()
     t.assert_error_msg_equals(
         "extensions/pupa.lua:1: module 'extensions.lupa' not found:\n" ..
         "\tno section 'extensions/lupa.lua' in config",
-        set_sections, {{
+        h.set_sections, g.srv, {{
             filename = 'extensions/pupa.lua',
             content = 'require("extensions.lupa")',
         }}
@@ -105,7 +83,7 @@ function g.test_require_errors()
     t.assert_error_msg_matches(
         "extensions/pupa%.lua:1: module 'lupa' not found:\n" ..
         "\tno field package.preload%['lupa'%].+",
-        set_sections, {{
+        h.set_sections, g.srv, {{
             filename = 'extensions/pupa.lua',
             content = 'require("lupa")',
         }, {
@@ -114,13 +92,13 @@ function g.test_require_errors()
         }}
     )
 
-    t.assert_equals(get_state(), 'RolesConfigured')
+    t.assert_equals(h.get_state(g.srv), 'RolesConfigured')
 end
 
 function g.test_functions_errors()
     t.assert_error_msg_equals(
         error_prefix .. 'bad field functions (table expected, got cdata)',
-        set_sections, {{
+        h.set_sections, g.srv, {{
             filename = 'extensions/config.yml',
             content = yaml.encode({
                 functions = box.NULL,
@@ -130,7 +108,7 @@ function g.test_functions_errors()
 
     t.assert_error_msg_equals(
         error_prefix .. 'bad field functions (table keys must be strings, got number)',
-        set_sections, {{
+        h.set_sections, g.srv, {{
             filename = 'extensions/config.yml',
             content = yaml.encode({
                 functions = {1},
@@ -140,7 +118,7 @@ function g.test_functions_errors()
 
     t.assert_error_msg_equals(
         error_prefix .. 'bad field functions["x"] (table expected, got cdata)',
-        set_sections, {{
+        h.set_sections, g.srv, {{
             filename = 'extensions/config.yml',
             content = yaml.encode({
                 functions = {x = box.NULL},
@@ -150,7 +128,7 @@ function g.test_functions_errors()
 
     t.assert_error_msg_equals(
         error_prefix .. 'bad field functions["x"].module (string expected, got cdata)',
-        set_sections, {{
+        h.set_sections, g.srv, {{
             filename = 'extensions/config.yml',
             content = yaml.encode({
                 functions = {x = {
@@ -162,7 +140,7 @@ function g.test_functions_errors()
 
     t.assert_error_msg_equals(
         error_prefix .. 'bad field functions["x"].handler (string expected, got number)',
-        set_sections, {{
+        h.set_sections, g.srv, {{
             filename = 'extensions/config.yml',
             content = yaml.encode({
                 functions = {x = {
@@ -175,7 +153,7 @@ function g.test_functions_errors()
 
     t.assert_error_msg_equals(
         error_prefix .. 'bad field functions["x"].events (table expected, got boolean)',
-        set_sections, {{
+        h.set_sections, g.srv, {{
             filename = 'extensions/config.yml',
             content = yaml.encode({
                 functions = {x = {
@@ -189,7 +167,7 @@ function g.test_functions_errors()
 
     t.assert_error_msg_equals(
         error_prefix .. "no module 'unknown' to handle function 'x'",
-        set_sections, {{
+        h.set_sections, g.srv, {{
             filename = 'extensions/config.yml',
             content = yaml.encode({
                 functions = {x = {
@@ -202,8 +180,9 @@ function g.test_functions_errors()
     )
 
     t.assert_error_msg_equals(
-        error_prefix .. "no function 'cat' in module 'box' to handle 'x'",
-        set_sections, {{
+        error_prefix .. "no function 'cat' in module 'box'" ..
+        " to handle 'x'",
+        h.set_sections, g.srv, {{
             filename = 'extensions/config.yml',
             content = yaml.encode({
                 functions = {x = {
@@ -230,7 +209,7 @@ function g.test_export_errors()
     t.assert_error_msg_equals(
         error_prefix .. "no module 'extensions.main'" ..
         " to handle function 'F'",
-        set_sections, {{
+        h.set_sections, g.srv, {{
             filename = 'extensions/config.yml',
             content = extensions_cfg,
         }}
@@ -239,7 +218,7 @@ function g.test_export_errors()
     t.assert_error_msg_equals(
         error_prefix .. "no function 'operate' in module 'extensions.main'" ..
         " to handle 'F'",
-        set_sections, {{
+        h.set_sections, g.srv, {{
             filename = 'extensions/config.yml',
             content = extensions_cfg,
         }, {
@@ -251,19 +230,19 @@ function g.test_export_errors()
     t.assert_error_msg_equals(
         error_prefix .. "no function 'operate' in module 'extensions.main'" ..
         " to handle 'F'",
-        set_sections, {{
+        h.set_sections, g.srv, {{
             filename = 'extensions/config.yml',
             content = extensions_cfg,
         }, {
             filename = 'extensions/main.lua',
-            content = 'return {operate = false}',
+            content = 'return {operate = "not-a-function"}',
         }}
     )
 
     t.assert_error_msg_equals(
         error_prefix .. "collision of binary event 'operate'" ..
         " to handle function 'F'",
-        set_sections, {{
+        h.set_sections, g.srv, {{
             filename = 'extensions/main.lua',
             content = 'return {operate = function() end}',
         }, {
@@ -284,7 +263,7 @@ function g.test_export_errors()
     t.assert_error_msg_equals(
         error_prefix .. "can't override global 'box'" ..
         " to handle function 'F'",
-        set_sections, {{
+        h.set_sections, g.srv, {{
             filename = 'extensions/main.lua',
             content = 'return {operate = function() end}',
         }, {
@@ -301,100 +280,5 @@ function g.test_export_errors()
         }}
     )
 
-    t.assert_equals(get_state(), 'RolesConfigured')
-end
-
-function g.test_runtime()
-    local extensions_cfg = yaml.encode({
-        functions = {
-            operate = {
-                module = 'extensions.main',
-                handler = 'operate',
-                events = {{
-                    binary = {path = 'operate'}
-                }}
-            },
-            math_abs = {
-                module = 'math',
-                handler = 'abs',
-                events = {{
-                    binary = {path = 'math_abs'}
-                }}
-            }
-        }
-    })
-
-    set_sections({{
-        filename = 'extensions/config.yml',
-        content = extensions_cfg,
-    }, {
-        filename = 'extensions/main.lua',
-        content = [[
-            local function M()
-                return require('extensions.main')
-            end
-
-            local function operate()
-                return 1
-            end
-
-            return {
-                M = M,
-                require = require,
-                operate = operate,
-            }
-        ]],
-    }})
-
-    t.assert_equals(g.cluster.main_server.net_box:call('math_abs', {-3}), 3)
-    t.assert_equals(g.cluster.main_server.net_box:call('operate'), 1)
-    g.cluster.main_server.net_box:eval([[
-        assert(package.loaded['extensions.main'], 'Extension not loaded')
-        local M = require('extensions.main')
-        assert(M == M.M(), 'Extension was reloaded twice')
-        assert(require ~= M.require, 'Upvalue "require" is broken')
-    ]])
-
-    t.assert_error_msg_equals(
-        error_prefix .. "no function 'operate'" ..
-        " in module 'extensions.main' to handle 'operate'",
-        set_sections, {{
-            filename = 'extensions/main.lua',
-            content = 'return {}',
-        }, {
-            filename = 'extensions/config.yml',
-            content = extensions_cfg,
-        }}
-    )
-    t.assert_error_msg_equals(
-        error_prefix .. "no module 'extensions.main'" ..
-        " to handle function 'operate'",
-        set_sections, {{
-            filename = 'extensions/main.lua',
-            content = box.NULL,
-        }, {
-            filename = 'extensions/config.yml',
-            content = extensions_cfg,
-        }}
-    )
-
-    set_sections({{
-        filename = 'extensions/config.yml',
-        content = extensions_cfg,
-    }, {
-        filename = 'extensions/main.lua',
-        content = [[
-            local function operate()
-                return 2
-            end
-
-            return {
-                operate = operate,
-            }
-        ]],
-    }})
-
-    t.assert_equals(g.cluster.main_server.net_box:call('operate'), 2)
-
-    t.assert_equals(get_state(), 'RolesConfigured')
+    t.assert_equals(h.get_state(g.srv), 'RolesConfigured')
 end

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -1,6 +1,6 @@
 local fio = require('fio')
 
-local helper = {}
+local helper = table.copy(require('cartridge.test-helpers'))
 
 helper.root = fio.dirname(fio.abspath(package.search('extensions')))
 helper.server_command = fio.pathjoin(helper.root, 'test', 'srv_basic.lua')
@@ -11,6 +11,23 @@ function helper.table_find_by_attr(tbl, key, value)
             return v
         end
     end
+end
+
+function helper.set_sections(srv, sections)
+    return srv:graphql({
+        query = [[
+            mutation($sections: [ConfigSectionInput!]) {
+                cluster {config(sections: $sections) {}}
+            }
+        ]],
+        variables = {sections = sections},
+    })
+end
+
+function helper.get_state(srv)
+    return srv.net_box:eval([[
+        return require('cartridge.confapplier').get_state()
+    ]])
 end
 
 return helper


### PR DESCRIPTION
On the eve of the http events implementation:

- Move tests across files
- Remove two redundant (duplicate) assertions