### PR TITLE
Handle role stop

### DIFF
--- a/extensions.lua
+++ b/extensions.lua
@@ -291,9 +291,9 @@ local function apply_config(conf)
     local httpd = require('cartridge').service_get('httpd')
 
     if httpd ~= nil then
-        for r_name, _ in pairs(vars.http_exports) do
-            local n = httpd.iroutes[r_name]
-            httpd.iroutes[r_name] = nil
+        for name, _ in pairs(vars.http_exports) do
+            local n = assert(httpd.iroutes[name])
+            httpd.iroutes[name] = nil
             table.remove(httpd.routes, n)
         end
 
@@ -328,8 +328,13 @@ local function apply_config(conf)
     vars.http_exports = c.http_exports
 end
 
+local function stop()
+    return apply_config({})
+end
+
 return {
     role_name = 'extensions',
     validate_config = validate_config,
     apply_config = apply_config,
+    stop = stop,
 }

--- a/test/lifecycle_test.lua
+++ b/test/lifecycle_test.lua
@@ -1,0 +1,117 @@
+local fio = require('fio')
+local yaml = require('yaml')
+local t = require('luatest')
+local h = require('test.helper')
+local g = t.group()
+
+
+g.before_all(function()
+    g.cluster = h.Cluster:new({
+        datadir = fio.tempdir(),
+        use_vshard = false,
+        server_command = h.server_command,
+        replicasets = {{
+            alias = 'loner',
+            roles = {'extensions'},
+            servers = 1,
+        }}
+    })
+
+    g.cluster:start()
+    g.srv = g.cluster.main_server
+    h.set_sections(g.srv, {{
+        filename = 'extensions/main.lua',
+        content = [[
+            local function ping()
+                return {status = 204}
+            end
+            return {ping = ping}
+        ]],
+    }, {
+        filename = 'extensions/config.yml',
+        content = yaml.encode({
+            functions = {
+                ping = {
+                    module = 'extensions.main',
+                    handler = 'ping',
+                    events = {{
+                        binary = {path = 'ping'},
+                        http = {path = 'ping', method = 'get'},
+                    }}
+                }
+            }
+        })
+    }})
+end)
+
+g.after_all(function()
+    g.cluster:stop()
+    fio.rmtree(g.cluster.datadir)
+end)
+
+function g.test_stop()
+    local edit_topology = [[
+        local ok, err = require('cartridge').admin_edit_topology({
+            replicasets = {...}
+        })
+        assert(ok, tostring(err))
+        return true
+    ]]
+
+    -- Disable
+    g.srv.net_box:eval(edit_topology, {{
+        uuid = g.srv.replicaset_uuid,
+        roles = {},
+    }})
+
+    t.assert_error_msg_equals(
+        "Procedure 'ping' is not defined",
+        function() return g.srv.net_box:call('ping') end
+    )
+    t.assert_covers(
+        g.srv:http_request('get', '/ping', {raise = false}),
+        {status = 404}
+    )
+
+    -- Re-enable
+    g.srv.net_box:eval(edit_topology, {{
+        uuid = g.srv.replicaset_uuid,
+        roles = {'extensions'},
+    }})
+
+    t.assert_equals(
+        g.srv.net_box:call('ping'),
+        {status = 204}
+    )
+    t.assert_covers(
+        g.srv:http_request('get', '/ping'),
+        {status = 204}
+    )
+end
+
+function g.test_reload()
+    local get_routes_count = [[
+        local httpd = require('cartridge').service_get('httpd')
+        return #httpd.routes
+    ]]
+    local routes_count = g.srv.net_box:eval(get_routes_count)
+
+    t.assert_equals(
+        {g.srv.net_box:call('package.loaded.cartridge.reload_roles')},
+        {true, nil}
+    )
+
+    t.assert_equals(
+        g.srv.net_box:call('ping'),
+        {status = 204}
+    )
+    t.assert_covers(
+        g.srv:http_request('get', '/ping'),
+        {status = 204}
+    )
+
+    t.assert_equals(
+        g.srv.net_box:eval(get_routes_count),
+        routes_count
+    )
+end

--- a/test/srv_basic.lua
+++ b/test/srv_basic.lua
@@ -15,6 +15,7 @@ local ok, err = errors.pcall('CartridgeCfgError', cartridge.cfg, {
     advertise_uri = 'localhost:3301',
     http_port = 8081,
     bucket_count = 3000,
+    roles_reload_allowed = true,
     roles = {
         'cartridge.roles.vshard-storage',
         'cartridge.roles.vshard-router',


### PR DESCRIPTION
Before this patch disabling the role wasn't handled at all.

Also, cartridge `reload_roles` is tested in this PR.