### PR TITLE
Fix setting defaults examples

### DIFF
--- a/extensions.lua
+++ b/extensions.lua
@@ -40,19 +40,31 @@ local _module_example = [[-- local M = {}
 -- return M
 ]]
 
+vars.example_sections = {
+    config = 'extensions/config.yml',
+    example = 'extensions/example.lua',
+}
+
 vars.example = {
-    ['extensions/config.yml'] = _config_example,
-    ['extensions/example.lua'] = _module_example,
+    [vars.example_sections.config] = _config_example,
+    [vars.example_sections.example] = _module_example,
 }
 
 -- Be gentle with cartridge.reload_roles
 twophase.on_patch(nil, vars.on_patch_trigger)
 function vars.on_patch_trigger(conf_new)
-    for k, v in pairs(vars.example) do
-        local section_yml = conf_new:get_plaintext(k)
-        if section_yml == nil or section_yml == '' then
-            conf_new:set_plaintext(k, v)
-        end
+    local extension_cfg_txt = conf_new:get_plaintext(vars.example_sections.config)
+    if extension_cfg_txt == nil or extension_cfg_txt == '' then
+        conf_new:set_plaintext(
+            vars.example_sections.config, vars.example[vars.example_sections.config]
+        )
+    end
+
+    local extension_example_txt = conf_new:get_plaintext(vars.example_sections.example)
+    if extension_example_txt == '' then
+        conf_new:set_plaintext(
+            vars.example_sections.example, vars.example[vars.example_sections.example]
+        )
     end
 end
 twophase.on_patch(vars.on_patch_trigger, nil)

--- a/extensions.lua
+++ b/extensions.lua
@@ -40,31 +40,21 @@ local _module_example = [[-- local M = {}
 -- return M
 ]]
 
-vars.example_sections = {
-    config = 'extensions/config.yml',
-    example = 'extensions/example.lua',
-}
-
-vars.example = {
-    [vars.example_sections.config] = _config_example,
-    [vars.example_sections.example] = _module_example,
-}
-
 -- Be gentle with cartridge.reload_roles
 twophase.on_patch(nil, vars.on_patch_trigger)
 function vars.on_patch_trigger(conf_new)
-    local extension_cfg_txt = conf_new:get_plaintext(vars.example_sections.config)
-    if extension_cfg_txt == nil or extension_cfg_txt == '' then
-        conf_new:set_plaintext(
-            vars.example_sections.config, vars.example[vars.example_sections.config]
-        )
+    local config_txt = conf_new:get_plaintext('extensions/config.yml')
+    if config_txt == nil or config_txt == '' then
+        conf_new:set_plaintext('extensions/config.yml', _config_example)
+    else
+        -- Don't interfere other sections
+        -- if `config.yml` already exists.
+        return
     end
 
-    local extension_example_txt = conf_new:get_plaintext(vars.example_sections.example)
-    if extension_example_txt == '' then
-        conf_new:set_plaintext(
-            vars.example_sections.example, vars.example[vars.example_sections.example]
-        )
+    local module_txt = conf_new:get_plaintext('extensions/example.lua')
+    if module_txt == nil or module_txt == '' then
+        conf_new:set_plaintext('extensions/example.lua', _module_example)
     end
 end
 twophase.on_patch(vars.on_patch_trigger, nil)

--- a/extensions.lua
+++ b/extensions.lua
@@ -48,12 +48,11 @@ vars.example = {
 -- Be gentle with cartridge.reload_roles
 twophase.on_patch(nil, vars.on_patch_trigger)
 function vars.on_patch_trigger(conf_new)
-    if conf_new:get_readonly('extensions/config') ~= nil then
-        return
-    end
-
     for k, v in pairs(vars.example) do
-        conf_new:set_plaintext(k, v)
+        local section_yml = conf_new:get_plaintext(k)
+        if section_yml == nil or section_yml == '' then
+            conf_new:set_plaintext(k, v)
+        end
     end
 end
 twophase.on_patch(vars.on_patch_trigger, nil)

--- a/test/example_test.lua
+++ b/test/example_test.lua
@@ -33,48 +33,44 @@ local function uncomment(text, prefix)
     return table.concat(lines, '\n')
 end
 
-local function grab_example_cfg(server)
-    local sections = {}
-    for _, s in ipairs(h.get_sections(server)) do
-        require('log').info(s.filename)
-        if s.filename:match('^extensions/.*$') then
-            sections[s.filename] = s.content
-        end
-    end
-    return sections
+function g.test_custom_config()
+    -- Ensure example.lua isn't overriden
+    t.assert_error_msg_equals(
+        '"localhost:13301": one',
+        h.set_sections, g.srv, {{
+            filename = 'extensions/config.yml',
+            content = box.NULL,
+        }, {
+            filename = 'extensions/example.lua',
+            content = 'error("one", 0)',
+        }}
+    )
+
+    -- Ensure example.lua can be removed
+    h.set_sections(g.srv, {{
+        filename = 'extensions/config.yml',
+        content = '# Draft config',
+    }, {
+        filename = 'extensions/example.lua',
+        content = box.NULL,
+    }})
+    t.assert_equals(
+        h.get_sections(g.srv),
+        {{
+            filename = 'extensions/config.yml',
+            content = '# Draft config',
+        }}
+    )
 end
 
 function g.test_example_config()
-    local cfg_key = 'extensions/config.yml'
-    local code_key = 'extensions/example.lua'
-
-    local examples = g.srv.net_box:eval([[
-        return require('cartridge.vars').new('cartridge.roles.extensions').example
-    ]])
-
-    t.assert_equals(grab_example_cfg(g.srv), { [cfg_key] = examples[cfg_key] })
-
-    -- test set example.lua works
     h.set_sections(g.srv, {{
-        filename = code_key,
-        content = examples[code_key]
+        filename = 'extensions/config.yml',
+        content = box.NULL,
+    }, {
+        filename = 'extensions/example.lua',
+        content = box.NULL,
     }})
-    t.assert_equals(grab_example_cfg(g.srv), examples)
-
-    -- test unset example.lua works
-    h.set_sections(g.srv, {{
-        filename = code_key,
-        content = nil
-    }})
-    t.assert_equals(grab_example_cfg(g.srv), { [cfg_key] = examples[cfg_key] })
-
-    -- test change example.lua works
-    examples[code_key] = '\n-- require("log").info("smth")\n' .. examples[code_key]
-    h.set_sections(g.srv, {{
-        filename = code_key,
-        content = examples[code_key]
-    }})
-    t.assert_equals(grab_example_cfg(g.srv), examples)
 
     local sections = {}
     for _, s in ipairs(h.get_sections(g.srv)) do


### PR DESCRIPTION
This patch fixes the user experience. Previously it used to substitute example config even if a user already modified it.