### PR TITLE
Fix tests for a fresh cartridge

### DIFF
--- a/test/example_test.lua
+++ b/test/example_test.lua
@@ -54,7 +54,7 @@ function g.test_custom_config()
         filename = 'extensions/example.lua',
         content = box.NULL,
     }})
-    t.assert_equals(
+    t.assert_items_include(
         h.get_sections(g.srv),
         {{
             filename = 'extensions/config.yml',


### PR DESCRIPTION
Recently we've updated a ddl module in cartridge which added a new
example schema into the clusterwide config. This patch reflects this
new feature in tests.

See also https://github.com/tarantool/ddl/pull/61