### PR TITLE
api: add hardcoded versioning support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,16 @@ env:
   CMAKE_DUMMY_WEBUI: true
 
 jobs:
+  version-check:
+    # We need this job to run only on push with tag.
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check module version
+        uses: tarantool/actions/check-module-version@master
+        with:
+          module-name: 'extensions'
+
   publish-scm-1:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-20.04
@@ -22,6 +32,7 @@ jobs:
 
   publish-tag:
     if: startsWith(github.ref, 'refs/tags/')
+    needs: version-check
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Versioning support.
+
 ## [1.1.0] - 2021-08-09
 
 ### Added

--- a/extensions.lua
+++ b/extensions.lua
@@ -7,6 +7,10 @@ local vars = require('cartridge.vars').new('cartridge.roles.extensions')
 local RequireExtensionError = errors.new_class('RequireExtensionError')
 local ExtensionConfigError = errors.new_class('ExtensionConfigError')
 
+-- Сontains the module version.
+-- Requires manual update in case of release commit.
+local VERSION = '1.1.0'
+
 vars:new('loaded', {})
 vars:new('exports', {})
 vars:new('http_exports', {})
@@ -386,4 +390,5 @@ return {
     validate_config = validate_config,
     apply_config = apply_config,
     stop = stop,
+    _VERSION = VERSION,
 }


### PR DESCRIPTION
Add versioning support, now the module api has `_VERSION` hardcoded variable. Is part of the task [1].

1. https://github.com/tarantool/roadmap-internal/issues/204